### PR TITLE
Add: Added options in put method

### DIFF
--- a/src/Drivers/index.js
+++ b/src/Drivers/index.js
@@ -93,12 +93,12 @@ class AzureStorage {
     })
   }
 
-  put (relativePath, content) {
+  put (relativePath, content, options = {}) {
     const blockBlobClient = this.getBlockBlobClient(relativePath)
 
     return new Promise((resolve, reject) => {
       try {
-        blockBlobClient.upload(content, content.length).then(response => {
+        blockBlobClient.upload(content, content.length, options).then(response => {
           resolve(response)
         })
       } catch (err) {


### PR DESCRIPTION
Increment options on put.
Allows you to set other parameters on upload. This way, we can pass parameters such as for example; BlobHTTPHeaders, which allows you to define the contentType.